### PR TITLE
ねこ一覧画面に検索/ソート機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 gem "kaminari"
+gem "ransack"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,10 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis (5.2.0)
@@ -253,6 +257,7 @@ DEPENDENCIES
   kaminari
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  ransack
   redis (>= 4.0.1)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -2,7 +2,9 @@ class CatsController < ApplicationController
   before_action :set_cat, only: %i[ show edit update destroy ]
 
   def index
-    @cats = Cat.page(params[:page])
+    @search = Cat.ransack(params[:q])
+    @search.sorts = 'id desc' if @search.sorts.empty?
+    @cats = @search.result.page(params[:page])
   end
 
   # GET /cats/1

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -1,2 +1,5 @@
 class Cat < ApplicationRecord
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name age]
+  end
 end

--- a/app/views/cats/index.html.erb
+++ b/app/views/cats/index.html.erb
@@ -2,6 +2,17 @@
 
 <h1>Cats</h1>
 
+<%= search_form_for @search do |f| %>
+  <%= f.label :name_cont, "名前" %>
+  <%= f.search_field :name_cont %>
+
+  <%= f.label :age_eq, "年齢" %>
+  <%= f.search_field :age_eq %>
+
+  <%= f.submit %>
+  <%= link_to "クリア", cats_path %>
+<% end %>
+
 <div id="cats">
   <% @cats.each do |cat| %>
     <%= render cat %>

--- a/app/views/cats/index.html.erb
+++ b/app/views/cats/index.html.erb
@@ -13,6 +13,9 @@
   <%= link_to "クリア", cats_path %>
 <% end %>
 
+<%= sort_link @search, :name %>
+<%= sort_link @search, :age %>
+
 <div id="cats">
   <% @cats.each do |cat| %>
     <%= render cat %>


### PR DESCRIPTION
### 実装内容
- [ねこの名前、年齢による検索機能](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-1#%E6%A4%9C%E7%B4%A2%E3%81%AE%E5%AE%9F%E8%A3%85)
- [ねこの名前、年齢によるソート機能
](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-1#%E3%82%BD%E3%83%BC%E3%83%88%E3%81%AE%E5%AE%9F%E8%A3%85)

### 確認方法
http://localhost:3000/cats にアクセスして検索、ソートが出来ることを確認してみてください。