### PR TITLE
ねこの属性にバリデーション追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem "bootstrap_form"
 gem "kaminari"
 gem "ransack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
+    bootstrap_form (5.4.0)
+      actionpack (>= 6.1)
+      activemodel (>= 6.1)
     builder (3.2.4)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -251,6 +254,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bootstrap_form
   cssbundling-rails
   debug
   importmap-rails

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,7 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+
+label.required::after {
+  content: " *";
+  color: red;
+}

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -1,4 +1,7 @@
 class Cat < ApplicationRecord
+  validates :name, presence: true
+  validates :age, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[name age]
   end

--- a/app/views/cats/_form.html.erb
+++ b/app/views/cats/_form.html.erb
@@ -1,5 +1,5 @@
-<%= bootstrap_form_with(model: cat) do |form| %>
+<%= bootstrap_form_with(model: cat, html: { novalidate: true }) do |form| %>
   <%= form.text_field :name %>
-  <%= form.text_field :age %>
+  <%= form.number_field :age %>
   <%= form.primary %>
 <% end %>

--- a/app/views/cats/_form.html.erb
+++ b/app/views/cats/_form.html.erb
@@ -1,27 +1,5 @@
-<%= form_with(model: cat) do |form| %>
-  <% if cat.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(cat.errors.count, "error") %> prohibited this cat from being saved:</h2>
-
-      <ul>
-        <% cat.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name %>
-  </div>
-
-  <div>
-    <%= form.label :age, style: "display: block" %>
-    <%= form.number_field :age %>
-  </div>
-
-  <div>
-    <%= form.submit %>
-  </div>
+<%= bootstrap_form_with(model: cat) do |form| %>
+  <%= form.text_field :name %>
+  <%= form.text_field :age %>
+  <%= form.primary %>
 <% end %>


### PR DESCRIPTION
### 実装内容
- ねこの名前、年齢にバリデーション追加
- 入力フォームをbootstrap_formに置き換え

[インラインバリデーションの実装](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-1#%E3%82%A4%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%B3%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E5%AE%9F%E8%A3%85)

### 確認方法
[ねこ新規作成画面](http://localhost:3000/cats/new)、編集画面においてバリデーションに引っ掛かるとメッセージが表示されることを確認してみてください。