### PR TITLE
ページネーション・ソート・検索時にURLが更新されるように修正

### DIFF
--- a/app/views/cats/index.html.erb
+++ b/app/views/cats/index.html.erb
@@ -45,7 +45,7 @@
   </div>
 
   <div class="card-body mx-3">
-    <%= turbo_frame_tag "cats-list" do %>
+    <%= turbo_frame_tag "cats-list", data: { turbo_action: :advance } do %>
       <div class="row py-2">
         <div class="col-4 mt-auto">
           <%= sort_link(@search, :name) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>Rails7Hotwire</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="turbo-cache-control" content="no-cache">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
### 実装内容
- [Turboのキャッシュの無効化](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-3#turbo%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E3%81%AE%E7%84%A1%E5%8A%B9%E5%8C%96)
- [ページネーション・ソート・検索時にURLが更新されるように修正](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-3#%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%83%BB%E3%82%BD%E3%83%BC%E3%83%88%E3%83%BB%E6%A4%9C%E7%B4%A2%E6%99%82%E3%81%ABurl%E3%81%8C%E6%9B%B4%E6%96%B0%E3%81%95%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E4%BF%AE%E6%AD%A3)

### 確認方法
[ねこ一覧画面](http://localhost:3000/cats) でページネーション、ソート、検索を実行した際にURLが変わっていることを確認してみてください。