### PR TITLE
メッセージをトーストに変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,6 @@ module ApplicationHelper
   end
 
   def turbo_stream_flash
-    turbo_stream.update "flash", partial: "flash"
+    turbo_stream.append "flashes", partial: "flash"
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -11,3 +11,6 @@ application.register("hello", HelloController)
 
 import ModalController from "./modal_controller.js"
 application.register("modal", ModalController)
+
+import ToastController from "./toast_controller.js"
+application.register("toast", ToastController)

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+import { Toast } from "bootstrap"
+
+// Connects to data-controller="toast"
+export default class extends Controller {
+  connect() {
+    const toast = new Toast(this.element)
+    toast.show()
+  }
+}

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,13 +1,19 @@
 <% if notice %>
-  <div class="alert alert-primary alert-dismissible">
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    <%= notice %>
+  <div class="mb-2 toast hide border-primary" data-controller="toast">
+    <div class="toast-header text-primary">
+      <strong class="me-auto"><%= icon_with_text("check-circle", "成功") %></strong>
+      <button type="button" class="btn-close" data-bs-dismiss="toast">
+    </div>
+    <div class="toast-body"><%= notice %></div>
   </div>
 <% end %>
 
 <% if alert %>
-  <div class="alert alert-danger alert-dismissible">
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    <%= alert %>
+  <div class="mb-2 toast hide border-danger" data-controller="toast">
+    <div class="toast-header text-danger">
+      <strong class="me-auto"><%= icon_with_text("exclamation-circle", "エラー") %></strong>
+      <button type="button" class="btn-close" data-bs-dismiss="toast">
+    </div>
+    <div class="toast-body"><%= alert %></div>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,14 +21,12 @@
           </div>
 
           <div class="col my-4">
-            <div id="flash">
-              <%= render "flash" %>
-            </div>
             <%= yield %>
           </div>
         </div>
       </div>
     </div>
     <%= turbo_frame_tag "modal" %>
+    <div id="flashes" class="position-fixed top-0 end-0" style="margin: 0.75rem"></div>
   </body>
 </html>


### PR DESCRIPTION
### 実装内容
[FlashにToastを利用する](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/tutorial-3#flash%E3%81%ABtoast%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B)

### 確認方法
[ねこ一覧画面](http://localhost:3000/cats) から登録、編集、削除を実施するとメッセージがトースト形式で表示されることを確認してみてください。
（自分の環境では `rails assets:precompile` しないと反映されませんでした🤔）