### PR TITLE
コールバックにbroadcasts_toを使用

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -24,7 +24,6 @@ class CatsController < ApplicationController
     @cat = Cat.new(cat_params)
 
     if @cat.save
-      @cat.broadcast_prepend_to("cats")
       flash.now.notice = "ねこを登録しました。"
     else
       render :new, status: :unprocessable_entity
@@ -33,7 +32,6 @@ class CatsController < ApplicationController
 
   def update
     if @cat.update(cat_params)
-      @cat.broadcast_replace_to("cats")
       flash.now.notice = "ねこを更新しました。"
     else
       render :edit, status: :unprocessable_entity
@@ -42,7 +40,6 @@ class CatsController < ApplicationController
 
   def destroy
     @cat.destroy!
-    @cat.broadcast_remove_to("cats")
     flash.now.notice = "ねこを削除しました。"
   end
 

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -5,4 +5,6 @@ class Cat < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     %w[name age]
   end
+
+  broadcasts_to -> (_cat) { "cats" }, inserts_by: :prepend
 end


### PR DESCRIPTION
### 対応
- [更新・登録・削除のコールバックにbroadcasts_toを使うように修正](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-streams-websocket#%E6%9B%B4%E6%96%B0%E3%83%BB%E7%99%BB%E9%8C%B2%E3%83%BB%E5%89%8A%E9%99%A4%E3%81%AE%E3%82%B3%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF%E3%81%ABbroadcasts_to%E3%82%92%E4%BD%BF%E3%81%86%E3%82%88%E3%81%86%E3%81%AB%E4%BF%AE%E6%AD%A3)

### 動作確認
更新・登録・削除機能が壊れていないことを確認する。